### PR TITLE
feat: block Aquamirae keepsake network request (NeoForge)

### DIFF
--- a/common/src/main/java/dev/aika/smsn/config/SMSNConfig.java
+++ b/common/src/main/java/dev/aika/smsn/config/SMSNConfig.java
@@ -59,6 +59,8 @@ public class SMSNConfig extends ModConfig {
     public boolean voidscapeDonator = false;
     @LoaderSpecific(LoaderType.NEOFORGE)
     public boolean ironsLibPatreon = false;
+    @LoaderSpecific(LoaderType.NEOFORGE)
+    public boolean aquamiraeKeepsakeCheck = false;
 
     @Category("qol")
     @Components.Switch(checked = "enable", unchecked = "disabled")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ neoforge-allthecompatibility = { version = "1IfRn5Yp", module = "maven.modrinth:
 neoforge-citadel = { version = "2.7.0", module = "maven.modrinth:citadel" }
 #neoforge-citadel-unofficial = { version = "7432825", module = "curse.maven:citadel-1-21-1-port-1415723" }
 neoforge-alexscaves-unofficial = { version = "7518652", module = "curse.maven:alexs-caves-unofficial-port-1420348" } # 2.0.9
+neoforge-aquamirae = { version = "usuA98Eb", module = "maven.modrinth:aquamirae" } # 7.2.1
 #neoforge-fancytoasts = { version = "mRTW5IaJ", module = "maven.modrinth:fancy-toasts" } # 1.4.5.1
 neoforge-fancytoasts = { version = "ErhgSKSc", module = "maven.modrinth:fancy-toasts" } # 1.4.7
 neoforge-voidscape = { version = "7383510", module = "curse.maven:voidscape-251730" } # 1.9.583

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -119,6 +119,8 @@ dependencies {
     modImplementation(libs.neoforge.citadel)
 //    modImplementation(libs.neoforge.citadel.unofficial)
     modImplementation(libs.neoforge.alexscaves.unofficial)
+    // Aquamirae
+    modCompileOnly(libs.neoforge.aquamirae)
     // Fancy Toasts | Better Advancements
     modImplementation(libs.neoforge.fancytoasts)
     // Voidscape

--- a/neoforge/src/main/java/dev/aika/smsn/mixin/neoforge/MixinPlatformImpl.java
+++ b/neoforge/src/main/java/dev/aika/smsn/mixin/neoforge/MixinPlatformImpl.java
@@ -17,6 +17,9 @@ public class MixinPlatformImpl {
                         "dev.aika.smsn.neoforge.mixin.alex.CitadelConstantsMixin",
                         "dev.aika.smsn.neoforge.mixin.alex.CitadelWebHelperMixin"
                 ),
+                new ModMixinInfo("aquamirae",
+                        "dev.aika.smsn.neoforge.mixin.aquamirae.KeepsakeManagerMixin"
+                ),
                 new ModMixinInfo("nitrogen",
                         "dev.aika.smsn.neoforge.mixin.aetherteam.UserData$ServerMixin"
                 ),

--- a/neoforge/src/main/java/dev/aika/smsn/neoforge/mixin/aquamirae/KeepsakeManagerMixin.java
+++ b/neoforge/src/main/java/dev/aika/smsn/neoforge/mixin/aquamirae/KeepsakeManagerMixin.java
@@ -1,0 +1,17 @@
+package dev.aika.smsn.neoforge.mixin.aquamirae;
+
+import com.google.gson.JsonElement;
+import dev.aika.smsn.SMSN;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = dev.obscuria.aquamirae.common.patreon.KeepsakeManager.class, remap = false)
+public abstract class KeepsakeManagerMixin {
+    @Inject(method = "fetchFromSourceWithTimeout", at = @At("HEAD"), cancellable = true)
+    private static void fetchFromSourceWithTimeout(CallbackInfoReturnable<JsonElement> cir) {
+        if (SMSN.CONFIG.isAquamiraeKeepsakeCheck()) return;
+        cir.setReturnValue(null);
+    }
+}

--- a/neoforge/src/main/resources/smsn.mixins.json
+++ b/neoforge/src/main/resources/smsn.mixins.json
@@ -15,6 +15,7 @@
     "alex.AlexsCavesWebHelperMixin",
     "alex.CitadelConstantsMixin",
     "alex.CitadelWebHelperMixin",
+    "aquamirae.KeepsakeManagerMixin",
     "arsnouveau.RewardsMixin",
     "bagus_lib.TierHelperMixin",
     "exposure.GildedMixin",


### PR DESCRIPTION
> ⚠️ AI 生成声明
>
> 本 PR 由 AI 辅助生成，并经过人工实测验证。
> 按 GitHub 对 AI 生成内容的标注要求，特此明确说明。
> 使用/合并前请自行 review。

## What
Add a NeoForge mixin to skip Aquamirae's `KeepsakeManager.fetchFromSourceWithTimeout`
network request, preventing a 30s world-load stall when `raw.githubusercontent.com`
is slow/unreachable.

## Why
Aquamirae blocks the server thread for up to 30 seconds trying to fetch
Patreon keepsakes on every world load. SMSN should cover this like other
mod network checks.

## How
- New config: `aquamiraeKeepsakeCheck` (default `false` = blocked)
- New mixin: `neoforge/.../aquamirae/KeepsakeManagerMixin`
  - At HEAD of `fetchFromSourceWithTimeout`, return `null` when blocking is enabled
  - Aquamirae then falls back to its local cache, so functionality is preserved
- Registered in `MixinPlatformImpl` and `smsn.mixins.json`

## Test
- MC 1.21.1 / NeoForge 21.1.248 / SMSN 1.4.3 / Aquamirae 7.2.1
- Before: main menu -> in-game ~34s, log shows 30s keepsakes timeout
- After: ~7.5s, no timeout, Aquamirae loads keepsakes from cache
- 实测确认海灵物语正常使用本地缓存，不影响模组玩法